### PR TITLE
Patch Issue 6: "EmpyrionModHost.exe" ProcessStartInfo Arguments Resiliency

### DIFF
--- a/EWAModClient/EmpyrionModClient.cs
+++ b/EWAModClient/EmpyrionModClient.cs
@@ -164,7 +164,7 @@ namespace EWAModClient
                             $"-EmpyrionToModPipe {CurrentConfig.Current.EmpyrionToModPipeName}",
                             $"-ModToEmpyrionPipe {CurrentConfig.Current.ModToEmpyrionPipeName}",
                             $"-GameDir \"{ProgramPath}\"",
-                            Environment.GetCommandLineArgs().Aggregate(string.Empty, HandleQuoteWhenNotSwitch),
+                            Environment.GetCommandLineArgs().Aggregate(string.Empty, HandleQuoteWhenNotSwitchOrContainsQuote),
                             CurrentConfig.Current.AdditionalArguments ?? string.Empty),
                     }
                 };
@@ -395,13 +395,13 @@ namespace EWAModClient
                     Id               = Process.GetCurrentProcess().Id,
                     CurrentDirecrory = Directory.GetCurrentDirectory(),
                     FileName         = "EmpyrionDedicated.exe",
-                    Arguments        = Environment.GetCommandLineArgs().Aggregate(string.Empty, HandleQuoteWhenNotSwitch),
+                    Arguments        = Environment.GetCommandLineArgs().Aggregate(string.Empty, HandleQuoteWhenNotSwitchOrContainsQuote),
                 }
             });
         }
 
-        private string HandleQuoteWhenNotSwitch(string S, string A) => 
-            string.Format("{0} {1}", S, !Equals(A.FirstOrDefault(), '-') ? $"\"{A}\"" : A).Trim();        
+        private string HandleQuoteWhenNotSwitchOrContainsQuote(string S, string A) => 
+            string.Format("{0} {1}", S, !(Equals(A.FirstOrDefault(), '-') || A.Contains('"')) ? $"\"{A}\"" : A).Trim();        
 
         private void HandleGameEvent(EmpyrionGameEventData TypedMsg)
         {

--- a/EWAModClient/EmpyrionModClient.cs
+++ b/EWAModClient/EmpyrionModClient.cs
@@ -160,12 +160,12 @@ namespace EWAModClient
                         CreateNoWindow  = true,
                         WindowStyle     = ProcessWindowStyle.Hidden,
                         WorkingDirectory = Path.GetDirectoryName(HostFilename),
-                        Arguments = Environment.GetCommandLineArgs().Aggregate(
-                            $"-EmpyrionToModPipe {CurrentConfig.Current.EmpyrionToModPipeName} " + 
-                            $"-ModToEmpyrionPipe {CurrentConfig.Current.ModToEmpyrionPipeName} " +
+                        Arguments = string.Join(" ",
+                            $"-EmpyrionToModPipe {CurrentConfig.Current.EmpyrionToModPipeName}",
+                            $"-ModToEmpyrionPipe {CurrentConfig.Current.ModToEmpyrionPipeName}",
                             $"-GameDir \"{ProgramPath}\"",
-                            (C, A) => C + " " + A) +
-                            (CurrentConfig.Current.AdditionalArguments == null ? "" : " " + CurrentConfig.Current.AdditionalArguments),
+                            Environment.GetCommandLineArgs().Aggregate(string.Empty, HandleQuoteWhenNotSwitch),
+                            CurrentConfig.Current.AdditionalArguments ?? string.Empty),
                     }
                 };
 
@@ -395,10 +395,13 @@ namespace EWAModClient
                     Id               = Process.GetCurrentProcess().Id,
                     CurrentDirecrory = Directory.GetCurrentDirectory(),
                     FileName         = "EmpyrionDedicated.exe",
-                    Arguments        = Environment.GetCommandLineArgs().Aggregate("", (S, A) => S + " " + A),
+                    Arguments        = Environment.GetCommandLineArgs().Aggregate(string.Empty, HandleQuoteWhenNotSwitch),
                 }
             });
         }
+
+        private string HandleQuoteWhenNotSwitch(string S, string A) => 
+            string.Format("{0} {1}", S, !Equals(A.FirstOrDefault(), '-') ? $"\"{A}\"" : A).Trim();        
 
         private void HandleGameEvent(EmpyrionGameEventData TypedMsg)
         {


### PR DESCRIPTION
Handles #6 by quoting any arg that isn't a switch for `CreateHostProcess` and `ReturnProcessInformation`  